### PR TITLE
Rename gem to openvoxserver-ca and depend on openfact gem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 /pkg/
 /spec/reports/
 /tmp/
-puppetserver-ca-*.gem
+openvoxserver-ca-*.gem
 Gemfile.lock
 
 # rspec failure tracking

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,23 +1,15 @@
 # Contributing
 
-Issues should be filed in the Puppet Server project of Puppetlabs' JIRA instance:
-...
-
+Issues should be filed in [openvox-server GitHub Issues](https://github.com/OpenVoxProject/openvox-server/issues).
 
 All changes should have appropriate unit tests.
 
-
 Commits should follow the format of:
 ```
-(SERVER-XXXX) Imperative statement
+Imperative statement
 
 Longer description broken into paragraphs for what existed previously,
 why that was undesirable, what changed and why it is desirable.
 ```
 
-Where `SERVER-XXXX` is an issue number from JIRA. If there is no ticket that
-matches the contribution please use `(maint)` instead.
-
-Feel free to submit Pull Requests for any issue that interests you, but
-please be aware that requests not linked to prioritize work within our
-tracker will be responded to as we have time.
+Feel free to submit Pull Requests for any issue that interests you.

--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
-# Puppet Server's CA CLI Library
+# OpenVox Server's CA CLI Library
 
-This gem provides the functionality behind the Puppet Server CA interactions.
-The actual CLI executable lives within the Puppet Server project.
+This gem provides the functionality behind the OpenVox Server CA interactions.
+The actual CLI executable lives within the OpenVox Server project.
+This is a community implementation of the `puppetserver-ca` gem. 
 
 
 ## Installation
 
 You may install it yourself with:
 
-    $ gem install puppetserver-ca
+    $ gem install openvoxserver-ca
 
 
 ## Usage
@@ -26,9 +27,9 @@ To import a custom CA:
 puppetserver ca import --cert-bundle certs.pem --crl-chain crls.pem --private-key ca_key.pem
 ```
 
-The remaining actions provided by this gem require a running Puppet Server, since
+The remaining actions provided by this gem require a running OpenVox Server (Puppet Server), since
 it primarily uses the CA's API endpoints to do its work. The following examples
-assume that you are using the gem packaged within Puppet Server.
+assume that you are using the gem packaged within OpenVox Server.
 
 To sign a pending certificate request:
 ```
@@ -71,7 +72,7 @@ puppetserver ca --help
 ```
 
 This code in this project is licensed under the Apache Software License v2,
-please see the included [License](https://github.com/puppetlabs/puppetserver-ca-cli/blob/main/LICENSE.md)
+please see the included [License](https://github.com/OpenVoxProject/openvoxserver-ca-cli/blob/main/LICENSE.md)
 for more details.
 
 
@@ -85,19 +86,19 @@ To install this gem onto your local machine, run `bundle exec rake install`.
 
 ### Testing
 To test your changes on a VM:
-1. Build the gem with your changes: `gem build puppetserver-ca.gemspec`
-1. Copy the gem to your VM: `scp puppetserver-ca-<version>.gem <your-vm>:.`
-1. Install puppetserver (FOSS) by installing the relevant release package and then installing the puppetserver package. For example:
+1. Build the gem with your changes: `gem build openvoxserver-ca.gemspec`
+1. Copy the gem to your VM: `scp openvoxserver-ca-<version>.gem <your-vm>:.`
+1. Install openvox-server by installing the relevant release package and then installing the openvox-server package. For example:
     ```
-    $ wget http://nightlies.puppet.com/yum/puppet-nightly-release-el-7.noarch.rpm
-    $ rpm -i puppet-nightly-release-el-7.noarch.rpm
+    $ wget https://yum.voxpupuli.org/openvox8-release-el-9.noarch.rpm
+    $ rpm -i openvox8-release-el-9.noarch.rpm
     $ yum update
-    $ yum install -y puppetserver
+    $ yum install -y openvox-server
     ```
 1. Restart your shell so that puppet's bin dir is on your $PATH: `exec bash`
 1. Install the gem into puppet's gem directory using puppet's gem command:
     ```
-    $ /opt/puppetlabs/puppet/bin/gem install --install-dir "/opt/puppetlabs/puppet/lib/ruby/vendor_gems" puppetserver-ca-<version>.gem
+    $ /opt/puppetlabs/puppet/bin/gem install --install-dir "/opt/puppetlabs/puppet/lib/ruby/vendor_gems" openvoxserver-ca-<version>.gem
     ```
 1. To confirm that installation was successful, run `puppetserver ca --help`
 
@@ -107,11 +108,11 @@ Bug reports and feature requests are welcome via GitHub issues.
 
 For interactive questions feel free to post to #puppet or #puppet-dev on the Puppet Community Slack channel.
 
-Contributions are welcome at https://github.com/puppetlabs/puppetserver-ca-cli/pulls.
+Contributions are welcome at https://github.com/OpenVoxProject/openvoxserver-ca-cli/pulls.
 Contributors should both be sure to read the
-[contributing document](https://github.com/puppetlabs/puppetserver-ca-cli/blob/main/CONTRIBUTING.md)
+[contributing document](https://github.com/OpenVoxProject/openvoxserver-ca-cli/blob/main/CONTRIBUTING.md)
 and sign the [contributor license agreement](https://cla.puppet.com/).
 
 Everyone interacting with the project’s codebase, issue tracker, etc is expected
 to follow the
-[code of conduct](https://github.com/puppetlabs/puppetserver-ca-cli/blob/main/CODE_OF_CONDUCT.md).
+[code of conduct](https://github.com/OpenVoxProject/openvoxserver-ca-cli/blob/main/CODE_OF_CONDUCT.md).

--- a/openvoxserver-ca.gemspec
+++ b/openvoxserver-ca.gemspec
@@ -4,14 +4,14 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "puppetserver/ca/version"
 
 Gem::Specification.new do |spec|
-  spec.name          = "puppetserver-ca"
+  spec.name          = "openvoxserver-ca"
   spec.version       = Puppetserver::Ca::VERSION
-  spec.authors       = ["Puppet, Inc."]
-  spec.email         = ["release@puppet.com"]
+  spec.authors       = ["OpenVox Project"]
+  spec.email         = ["openvox@voxpupuli.org"]
   spec.license       = "Apache-2.0"
 
-  spec.summary       = %q{A simple CLI tool for interacting with Puppet Server's Certificate Authority}
-  spec.homepage      = "https://github.com/puppetlabs/puppetserver-ca-cli/"
+  spec.summary       = %q{A simple CLI tool for interacting with OpenVox Server's Certificate Authority}
+  spec.homepage      = "https://github.com/OpenVoxProject/openvoxserver-ca/"
 
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "facter", [">= 2.0.1", "< 5"]
+  spec.add_runtime_dependency "openfact", [">= 5.0.0", "< 6"]
 
   spec.add_development_dependency "bundler", ">= 1.16"
   spec.add_development_dependency "rake", ">= 12.3.3"


### PR DESCRIPTION
For discussion. 

This renames the gem to openvoxserver-ca and removes the dependency on facter by swapping it out with openfact

Should not be merged until https://github.com/OpenVoxProject/facter/pull/20 is merged.

If accepted, the repo should be renamed to ‘openvoxserver-ca’. 