### PR TITLE
Ignore the vendor directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /doc/
 /pkg/
 /spec/reports/
+/vendor/
 /tmp/
 openvoxserver-ca-*.gem
 Gemfile.lock


### PR DESCRIPTION
On CI, bundler store gems in the vendor directory.  As we have some
actions that commit added / modified files, we do not want them to add
the bundle to the repo.
