### PR TITLE
fix: if not running as root, don't attempt chown

### DIFF
--- a/lib/puppetserver/ca/utils/file_system.rb
+++ b/lib/puppetserver/ca/utils/file_system.rb
@@ -53,14 +53,18 @@ module Puppetserver
         def self.forcibly_symlink(source, link_target)
           FileUtils.remove_dir(link_target, true)
           FileUtils.symlink(source, link_target)
-          # Ensure the symlink has the same ownership as the source.
-          # This requires using `FileUtils.chown` rather than `File.chown`, as
-          # the latter will update the ownership of the source rather than the
-          # link itself.
-          # Symlink permissions are ignored in favor of the source's permissions,
-          # so we don't have to change those.
-          source_info = File.stat(source)
-          FileUtils.chown(source_info.uid, source_info.gid, link_target)
+
+          # Ensure the symlink has the same ownership as the source when running
+          # with privileges to change ownership.
+          if instance.running_as_root?
+            # This requires using `FileUtils.chown` rather than `File.chown`, as
+            # the latter will update the ownership of the source rather than the
+            # link itself.
+            # Symlink permissions are ignored in favor of the source's permissions,
+            # so we don't have to change those.
+            source_info = File.stat(source)
+            FileUtils.chown(source_info.uid, source_info.gid, link_target)
+          end
         end
 
         def initialize

--- a/spec/puppetserver/ca/utils/file_system_spec.rb
+++ b/spec/puppetserver/ca/utils/file_system_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+require 'tmpdir'
+require 'fileutils'
+
+require 'puppetserver/ca/utils/file_system'
+
+RSpec.describe Puppetserver::Ca::Utils::FileSystem do
+  describe '.forcibly_symlink' do
+    it 'creates a symlink without changing ownership when not running as root' do
+      Dir.mktmpdir do |tmpdir|
+        source = File.join(tmpdir, 'new_cadir')
+        link_target = File.join(tmpdir, 'old_cadir')
+        FileUtils.mkdir_p(source)
+        FileUtils.mkdir_p(link_target)
+
+        allow(described_class.instance).to receive(:running_as_root?).and_return(false)
+
+        expect(FileUtils).not_to receive(:chown)
+
+        described_class.forcibly_symlink(source, link_target)
+
+        expect(File.symlink?(link_target)).to be(true)
+        expect(File.readlink(link_target)).to eq(source)
+      end
+    end
+
+    it 'changes symlink ownership to match the source when running as root' do
+      Dir.mktmpdir do |tmpdir|
+        source = File.join(tmpdir, 'new_cadir')
+        link_target = File.join(tmpdir, 'old_cadir')
+        FileUtils.mkdir_p(source)
+        FileUtils.mkdir_p(link_target)
+
+        allow(described_class.instance).to receive(:running_as_root?).and_return(true)
+        allow(File).to receive(:stat).and_call_original
+
+        source_info = instance_double(File::Stat, uid: 123, gid: 456)
+        allow(File).to receive(:stat).with(source).and_return(source_info)
+
+        expect(FileUtils).to receive(:chown).with(123, 456, link_target)
+
+        described_class.forcibly_symlink(source, link_target)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hi!

`puppetserver ca setup` / `puppetserver ca import` currently fail in non-root/containerized environments when CA directory compatibility symlinks are created.

`Puppetserver::Ca::Utils::FileSystem.forcibly_symlink` always calls `FileUtils.chown(...)` on the symlink target after creating it.  
When running without `CAP_CHOWN` (for example, arbitrary UID containers), this raises `Errno::EPERM` and aborts the command.

This PR should ensure that ownership is only harmonized when running as root.

Added unit tests for `Puppetserver::Ca::Utils::FileSystem.forcibly_symlink`:

1. Non-root path creates the symlink and doesn't call `FileUtils.chown`
2. Root root path calls `FileUtils.chown` with source uid/gid

Also verified related setup/import specs still pass.

Thanks!

PS: This PR will remove the need for [this](https://github.com/dotconfig404/container-openvoxserver/blob/4927f631bfb15a1e9192edb3446fbefea7ca0a53/openvoxserver/Containerfile.alpine#L226)