### PR TITLE
Release workflow: remove unused option

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,6 @@ jobs:
   release:
     uses: OpenVoxProject/shared-actions/.github/workflows/release.yml@main
     with:
-      allowed_owner: 'OpenVoxProject'
       base-branch: ${{ github.event.inputs.base-branch }}
       version: ${{ github.event.inputs.version }}
     secrets:


### PR DESCRIPTION
allowed_owner doesn't exist anymore: https://github.com/OpenVoxProject/shared-actions/blob/2cb0beb6c984327e58134c52d50880ad45953040/.github/workflows/release.yml#L6-L29

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
<!-- For example, `Fixes #12345` -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [ ] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
