### PR TITLE
(PE-44595) Tolerate nil in munge_alt_names

### DIFF
--- a/lib/puppetserver/ca/utils/config.rb
+++ b/lib/puppetserver/ca/utils/config.rb
@@ -10,7 +10,10 @@ module Puppetserver
         end
 
         def self.munge_alt_names(names)
-          raw_names = names.split(/\s*,\s*/).map(&:strip)
+          # Tolerate a nil/empty value. A puppet.conf key that is present but
+          # has no value (e.g. `dns_alt_names =`) is read as nil rather than
+          # using the absent-key default, so callers can hand us nil here.
+          raw_names = names.to_s.split(/\s*,\s*/).map(&:strip)
           munged_names = raw_names.map do |name|
             # Prepend the DNS tag if no tag was specified
             if !name.start_with?("IP:") && !name.start_with?("DNS:")

--- a/spec/puppetserver/ca/utils/config_spec.rb
+++ b/spec/puppetserver/ca/utils/config_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+require 'puppetserver/ca/utils/config'
+
+RSpec.describe 'Puppetserver::Ca::Utils::Config' do
+  describe '.munge_alt_names' do
+    it 'prepends DNS: to unprefixed names and sorts/dedupes' do
+      expect(Puppetserver::Ca::Utils::Config.munge_alt_names('foo.com,IP:10.0.0.1,DNS:foo.com')).
+        to eq('DNS:foo.com, IP:10.0.0.1')
+    end
+
+    it 'returns an empty string for an empty string' do
+      expect(Puppetserver::Ca::Utils::Config.munge_alt_names('')).to eq('')
+    end
+
+    # PE-44595: a puppet.conf key that is present but has no value
+    # (`dns_alt_names =`) can be read as nil, so munge_alt_names must tolerate
+    # nil rather than crashing with `undefined method 'split' for nil`.
+    it 'returns an empty string for nil instead of crashing' do
+      expect { Puppetserver::Ca::Utils::Config.munge_alt_names(nil) }.not_to raise_error
+      expect(Puppetserver::Ca::Utils::Config.munge_alt_names(nil)).to eq('')
+    end
+  end
+end


### PR DESCRIPTION
`munge_alt_names` calls `names.split(/\s*,\s*/)`, which raises `undefined method 'split' for nil` when handed nil. A puppet.conf key that is present but has no value (`dns_alt_names =`) can be read as nil rather than falling back to the absent-key default, so `resolve_settings` passes that nil straight into `munge_alt_names` and `puppetserver ca generate` crashes.

This was hit during a PE disaster-recovery replica promotion: the promoted node's puppet.conf carried an empty `dns_alt_names =` line, so generating the console/SAML certs crashed here, leaving pe-console-services unable to start.

Coerce the argument with `to_s` so a nil/empty value resolves to an empty alt-names list instead of crashing. Defends every caller.

cherry-picked from 219fa0d9b607e840b853f7f5d5163c4354c42876 / https://github.com/puppetlabs/puppetserver-ca-cli/pull/126

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
<!-- For example, `Fixes #12345` -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [ ] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [ ] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
